### PR TITLE
Allow to disable role dependencies.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v0.2.1
+------
+
+*Unreleased*
+
+- Added ``preseed_dependencies`` to allow to disable role dependencies. [ypid]
+
 v0.2.0
 ------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,12 @@
 #   Preseed server configuration
 # --------------------------------
 
+# .. envvar:: preseed_dependencies
+#
+# Should the ``debops.preseed`` role manage it's own dependencies (nginx)?
+# If you want to setup them yourself, you should change this to False.
+preseed_dependencies: True
+
 # .. envvar:: preseed_subdomain
 #
 # Name of the subdomain which will be used to serve Preseed files

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ dependencies:
       - '{{ preseed_nginx_server_http  }}'
       - '{{ preseed_nginx_server_https }}'
     tags: [ 'depend::nginx', 'depend::nginx:preseed', 'depend-of::preseed', 'type::dependency' ]
+    when: (preseed_dependencies|d() | bool)
 
 galaxy_info:
   author: 'Maciej Delmanowski'


### PR DESCRIPTION
My use case: Setup preseed files using Ansible and serve them as
needed with a little python Webserver as I have a more ad hoc use for
it at the moment.
